### PR TITLE
Improve date parsing to be engine independent

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -2,3 +2,11 @@ examples/
 test/
 prepublish.js
 coverage/
+.babelrc
+.eslintignore
+.eslintrc
+.gitignore
+.min-wd
+.nvmrc
+.travis.yml
+coverage.js

--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ const USER_MAPPING = {
   hasRoles:    fields.generic({ callback: (data) => {
     return data.groups.length > 0;
   }}),
-  dateCreated: fields.date()
+  // format can be any moment.js-compatible format. When not specified, ISO-8601 format is the default.
+  dateCreated: fields.date({ format: 'YYYY-MM-DD' })
 };
 
 // Define a DTO which represents a single user
@@ -37,7 +38,7 @@ const user = new UserDTO({
   name: 'john_doe',
   validated: true,
   groups: ['administrator'],
-  dateCreated: '1997-07-16T19:20:30Z'
+  dateCreated: '1997-07-16'
 });
 
 console.log('Hello ' + user.name); // "Hello john_doe"
@@ -56,14 +57,14 @@ const users = new UserListDTO([
     name: 'john_doe',
     groups: ['owner'],
     validated: true,
-    dateCreated: '1997-07-16T19:20:30Z'
+    dateCreated: '1997-07-16'
   },
   {
     id: 124,
     name: 'jane_doe',
     groups: ['administrator'],
     validated: false,
-    dateCreated: '2015-12-15T07:36:25Z'
+    dateCreated: '2015-12-15'
   }
 ]);
 

--- a/lib/fields.js
+++ b/lib/fields.js
@@ -5,8 +5,9 @@
  */
 'use strict';
 
-var BaseDTO = require('./dto').BaseDTO
-  , errors = require('./errors');
+const moment = require('moment');
+const { BaseDTO } = require('./dto');
+const errors = require('./errors');
 
 /**
  * Field mapping options
@@ -122,33 +123,35 @@ function number(options) {
  * @throws InvalidPropertyError if property is empty or not parsable to a date
  */
 function date(options) {
+  options = options || { format: moment.ISO_8601 };
+
   return {
-    options: options || {},
-    fn: function(val) {
-      if(val === null) {
-        return val;
+    options: options,
+    fn: function(value) {
+      if(value === null) {
+        return value;
       }
 
-      if(val === undefined) {
+      if(value === undefined) {
         throw new errors.InvalidPropertyError('Required property is missing');
       }
 
-      // booleans can be parsed to dates
-      if(typeof val === 'boolean') {
-        throw new errors.InvalidPropertyError('Property cannot be converted to a date');
+      if(value instanceof Date) {
+        return value;
       }
 
-      if(val instanceof Date) {
-        return val;
+      // object and arrays can be parsed to dates by moment.
+      if(typeof value === 'object') {
+        throw new errors.InvalidPropertyError(`Property '${value}' cannot be converted to a date`);
       }
 
-      val = new Date(val);
+      const d = moment(value, options.format, true);
 
-      if(val.toString() === 'Invalid Date') {
-        throw new errors.InvalidPropertyError('Property cannot be converted to a date');
+      if(!d.isValid()) {
+        throw new errors.InvalidPropertyError(`Property '${value}' cannot be converted to a date`);
       }
 
-      return val;
+      return d.toDate();
     }
   };
 }

--- a/package.json
+++ b/package.json
@@ -51,7 +51,8 @@
   },
   "dependencies": {
     "babel-runtime": "^6.11.6",
-    "inherits": "^2.0.1"
+    "inherits": "^2.0.1",
+    "moment": "^2.15.1"
   },
   "engines": {
     "node": ">= 4.x"

--- a/test/test.fields.js
+++ b/test/test.fields.js
@@ -11,7 +11,6 @@ describe('fields', function() {
   it('contain correct properties', function() {
     utils.eachField(function(field) {
       expect(field().fn).to.be.a('function');
-      expect(field().options).to.deep.equal({});
     });
   });
 
@@ -111,12 +110,16 @@ describe('fields', function() {
       utils.fieldTypes.forEach(function(type) {
         const testVal = utils.valueForType(type);
 
-        if(['date', 'number'].indexOf(type) !== -1) {
+        if(['date'].indexOf(type) !== -1) {
           expect(fields.date().fn(testVal)).to.be.an.instanceof(Date);
           return;
         }
 
-        expect(function() { fields.date().fn(testVal); }).to.throw(errors.InvalidPropertyError);
+        expect(function() {
+          fields.date().fn(testVal);
+        }).to.throw(errors.InvalidPropertyError,
+          `InvalidPropertyError: Property '${testVal}' cannot be converted to a date`,
+          `Property '${testVal}' should have thrown an error when converting to a date.`);
       });
     });
   });


### PR DESCRIPTION
Safari/Mobile Safari isn't able to parse ISO-8601 date formats
using the default date constructor.
Make sure the parsing of dates is the same in all engines
using dtox by using moment.js for it.

This change introduces a format parameter which can be specified
in the field options and then parses the date string using the strict
settings of moment.

This is a BC break. We should increase semver-major after merging this.
